### PR TITLE
Removed log.Fatal as this causes software using this library to exit

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package slack
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/parnurzeal/gorequest"
 )
@@ -57,7 +56,6 @@ func Send(webhookUrl string, proxy string, payload Payload) []error {
 		End()
 
 	if err != nil {
-		log.Fatal(err)
 		return err
 	}
 	if resp.StatusCode >= 400 {


### PR DESCRIPTION
I ran into this because of a problem I hit when running in a container without SSL root certificate validation available. It would come up with this error and completely bomb my running container:

`2017/02/11 03:39:49 [Post https://hooks.slack.com/services/foo/bar/baz: x509: failed to load system roots and no roots provided]`

As a library, it would be great to avoid calling something that invokes os.exit. By removing log.Fatal, the error is simply passed back to my software and results in this error instead:

`2017/02/11 17:22:11 Slack publish error: [Post https://hooks.slack.com/services/foo/bar/baz: x509: failed to load system roots and no roots provided]`

This allows me to identify and handle the problem (pass it back to a healthcheck or something similar).