### PR TITLE
Add linkNames field to Payload

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ type Payload struct {
 	IconEmoji   string       `json:"icon_emoji,omitempty"`
 	Channel     string       `json:"channel,omitempty"`
 	Text        string       `json:"text,omitempty"`
+	LinkNames   string       `json:"link_names,omitempty"`
 	Attachments []Attachment `json:"attachments,omitempty"`
 }
 


### PR DESCRIPTION
It's enable to receive `link_names` parameter when post message to slack.
`link_names` parameter means find and link channel names and usernames.

https://api.slack.com/docs/message-formatting

> By default, Slack will not linkify channel names (starting with a '#') and usernames (starting with an '@'). You can enable this behavior by passing link_names=1 as an argument. 
