### PR TITLE
Add thumbnail url field to Attachment

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,23 +20,24 @@ type Action struct {
 }
 
 type Attachment struct {
-	Fallback   *string   `json:"fallback"`
-	Color      *string   `json:"color"`
-	PreText    *string   `json:"pretext"`
-	AuthorName *string   `json:"author_name"`
-	AuthorLink *string   `json:"author_link"`
-	AuthorIcon *string   `json:"author_icon"`
-	Title      *string   `json:"title"`
-	TitleLink  *string   `json:"title_link"`
-	Text       *string   `json:"text"`
-	ImageUrl   *string   `json:"image_url"`
-	Fields     []*Field  `json:"fields"`
-	Footer     *string   `json:"footer"`
-	FooterIcon *string   `json:"footer_icon"`
-	Timestamp  *int64    `json:"ts"`
-	MarkdownIn *[]string `json:"mrkdwn_in"`
-	Actions	   []*Action `json:"actions"`
-	CallbackID *string   `json:"callback_id"`
+	Fallback     *string   `json:"fallback"`
+	Color        *string   `json:"color"`
+	PreText      *string   `json:"pretext"`
+	AuthorName   *string   `json:"author_name"`
+	AuthorLink   *string   `json:"author_link"`
+	AuthorIcon   *string   `json:"author_icon"`
+	Title        *string   `json:"title"`
+	TitleLink    *string   `json:"title_link"`
+	Text         *string   `json:"text"`
+	ImageUrl     *string   `json:"image_url"`
+	Fields       []*Field  `json:"fields"`
+	Footer       *string   `json:"footer"`
+	FooterIcon   *string   `json:"footer_icon"`
+	Timestamp    *int64    `json:"ts"`
+	MarkdownIn   *[]string `json:"mrkdwn_in"`
+	Actions      []*Action `json:"actions"`
+	CallbackID   *string   `json:"callback_id"`
+	ThumbnailUrl *string   `json:"thumb_url"`
 }
 
 type Payload struct {


### PR DESCRIPTION
Slack displays a small thumbnail on messages where thumb_url is provided.
https://api.slack.com/docs/message-attachments